### PR TITLE
fix: nc command missing (required by wait-for script)

### DIFF
--- a/liferay/Dockerfile
+++ b/liferay/Dockerfile
@@ -1,5 +1,13 @@
 ARG BASE_IMAGE=liferay/dxp:7.3.10-ga1
 FROM ${BASE_IMAGE}
 
+USER root
+
+RUN apt update && \
+    apt install -y netcat && \
+    apt clean
+
+USER liferay:liferay
+
 ADD --chown=liferay:liferay https://raw.githubusercontent.com/eficode/wait-for/master/wait-for /usr/local/bin/
 RUN chmod +x /usr/local/bin/wait-for 


### PR DESCRIPTION
I encountered the following error message: `nc command is missing!`. The wait-for script included needs netcat and displays this error if netcat is not available (https://raw.githubusercontent.com/eficode/wait-for/master/wait-for). I believe it suddenly happens since Liferay switched from alpine to ubuntu as base image for the official Docker images.